### PR TITLE
Math round fix, regarding wBTC withdrawal problem

### DIFF
--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -1425,7 +1425,7 @@ class Store {
 
     var amountSend = web3.utils.toWei(amount, "ether")
     if (asset.decimals !== 18) {
-      amountSend = amount*10**asset.decimals;
+      amountSend = Math.round(amount*10**asset.decimals);
     }
 
     iEarnContract.methods.transfer(asset.iEarnContract, amountSend).send({ from: account.address, gasPrice: web3.utils.toWei(await this._getGasPrice(), 'gwei') })
@@ -1469,7 +1469,7 @@ class Store {
 
     var amountSend = web3.utils.toWei(amount, "ether")
     if (asset.decimals !== 18) {
-      amountSend = amount*10**asset.decimals;
+      amountSend = Math.round(amount*10**asset.decimals);
     }
 
     iEarnContract.methods[asset.redeem](amountSend).send({ from: account.address, gasPrice: web3.utils.toWei(await this._getGasPrice(), 'gwei') })
@@ -2663,7 +2663,7 @@ class Store {
 
     var amountSend = web3.utils.toWei(amount, "ether")
     if (asset.decimals !== 18) {
-      amountSend = amount*10**asset.decimals;
+      amountSend = Math.round(amount*10**asset.decimals);
     }
 
     let functionCall = vaultContract.methods.withdraw(amountSend)


### PR DESCRIPTION
The calculation for non 18 decimals token is causing number javascript error, generating a float number instead of integer one, hence causing web3 BigNumber error. I've just added Math.round method on all these calculations to guarantee we propagate the right number.

To generate the error: deposit wBTC to earn pool, then try to claim it. Check Chrome console.