### PR TITLE
Vault balance and value

### DIFF
--- a/src/components/vault/asset.jsx
+++ b/src/components/vault/asset.jsx
@@ -1,35 +1,3 @@
-Skip to content
-Search or jump to…
-
-Pull requests
-Issues
-Marketplace
-Explore
- 
-@fameal 
-fameal
-/
-iearn-finance
-forked from iearn-finance/iearn-finance
-0
-0101
-Code
-Pull requests
-Actions
-Projects
-Wiki
-Security
-Insights
-Settings
-iearn-finance/src/components/vault/asset.jsx
-@antonnell
-antonnell Cleaned up old, unused code.
-…
-Latest commit 53ff870 15 days ago
- History
- 1 contributor
-417 lines (380 sloc)  11.9 KB
-  
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
 import { withStyles } from '@material-ui/core/styles';
@@ -447,15 +415,3 @@ class Asset extends Component {
 }
 
 export default withRouter(withStyles(styles, { withTheme: true })(Asset));
-© 2020 GitHub, Inc.
-Terms
-Privacy
-Security
-Status
-Help
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About

--- a/src/components/vault/asset.jsx
+++ b/src/components/vault/asset.jsx
@@ -1,3 +1,35 @@
+Skip to content
+Search or jump to…
+
+Pull requests
+Issues
+Marketplace
+Explore
+ 
+@fameal 
+fameal
+/
+iearn-finance
+forked from iearn-finance/iearn-finance
+0
+0101
+Code
+Pull requests
+Actions
+Projects
+Wiki
+Security
+Insights
+Settings
+iearn-finance/src/components/vault/asset.jsx
+@antonnell
+antonnell Cleaned up old, unused code.
+…
+Latest commit 53ff870 15 days ago
+ History
+ 1 contributor
+417 lines (380 sloc)  11.9 KB
+  
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
 import { withStyles } from '@material-ui/core/styles';
@@ -165,7 +197,7 @@ class Asset extends Component {
     return (<div className={ classes.actionsContainer }>
       <div className={ classes.tradeContainer }>
         <div className={ classes.balances }>
-            <Typography variant='h4' onClick={ () => { this.setAmount(100) } } className={ classes.value } noWrap>{ 'Balance: '+ (asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset.tokenSymbol ? asset.tokenSymbol : asset.symbol }</Typography>
+            <Typography variant='h4' onClick={ () => { this.setAmount(100) } } className={ classes.value } noWrap>{ 'Your wallet: '+ (asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset.tokenSymbol ? asset.tokenSymbol : asset.symbol }</Typography>
         </div>
         <TextField
           fullWidth
@@ -248,7 +280,7 @@ class Asset extends Component {
       <div className={ classes.sepperator }></div>
       <div className={classes.tradeContainer}>
         <div className={ classes.balances }>
-          <Typography variant='h4' onClick={ () => { this.setRedeemAmount(100) } }  className={ classes.value } noWrap>{ asset.vaultBalance ? (Math.floor(asset.vaultBalance*10000)/10000).toFixed(4) : '0.0000' } { asset.vaultSymbol } ({ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(4) : '0.0000') } { asset.symbol }) </Typography>
+          <Typography variant='h4' onClick={ () => { this.setRedeemAmount(100) } }  className={ classes.value } noWrap>{ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(4) : '0.0000') } { asset.symbol } ({ asset.vaultBalance ? (Math.floor(asset.vaultBalance*10000)/10000).toFixed(4) : '0.0000' } { asset.vaultSymbol }) </Typography>
         </div>
         <TextField
           fullWidth
@@ -415,3 +447,15 @@ class Asset extends Component {
 }
 
 export default withRouter(withStyles(styles, { withTheme: true })(Asset));
+© 2020 GitHub, Inc.
+Terms
+Privacy
+Security
+Status
+Help
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About

--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -462,7 +462,7 @@ class Vault extends Component {
               {
                 (!['LINK'].includes(asset.id) && asset.vaultBalance > 0) &&
                 <div className={classes.headingEarning}>
-                  <Typography variant={ 'h5' } className={ classes.grey }>You are earning:</Typography>
+                  <Typography variant={ 'h5' } className={ classes.grey }>APY:</Typography>
                   <div className={ classes.flexy }>
                     <Typography variant={ 'h3' } noWrap>{ (asset.apy ? (asset.apy).toFixed(2) : '0.00') }% </Typography>
                     <Typography variant={ 'h5' } className={ classes.on }> on </Typography>
@@ -473,7 +473,7 @@ class Vault extends Component {
               {
                 (!['LINK'].includes(asset.id) && asset.vaultBalance === 0) &&
                 <div className={classes.headingEarning}>
-                  <Typography variant={ 'h5' } className={ classes.grey }>This vault is earning:</Typography>
+                  <Typography variant={ 'h5' } className={ classes.grey }>APY:</Typography>
                   <div className={ classes.flexy }>
                     <Typography variant={ 'h3' } noWrap>{ (asset.apy ? (asset.apy).toFixed(2) : '0.00') }% </Typography>
                   </div>
@@ -482,12 +482,12 @@ class Vault extends Component {
               {
                 ['LINK'].includes(asset.id) &&
                 <div className={classes.headingEarning}>
-                  <Typography variant={ 'h5' } className={ classes.grey }>You are earning:</Typography>
+                  <Typography variant={ 'h5' } className={ classes.grey }>APY:</Typography>
                   <Typography variant={ 'h3' } noWrap>Not Available</Typography>
                 </div>
               }
               <div className={classes.heading}>
-                <Typography variant={ 'h5' } className={ classes.grey }>Available to deposit:</Typography>
+                <Typography variant={ 'h5' } className={ classes.grey }>Your wallet:</Typography>
                 <Typography variant={ 'h3' } noWrap>{ (asset.balance ? (asset.balance).toFixed(2) : '0.00')+' '+asset.symbol }</Typography>
               </div>
             </div>

--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -461,7 +461,7 @@ class Vault extends Component {
               </div>
               {
                 (!['LINK'].includes(asset.id) && asset.vaultBalance > 0) &&
-                <div className={classes.headingEarning}>
+                <div className={classes.heading}>
                   <Typography variant={ 'h5' } className={ classes.grey }>APY:</Typography>
                   <div className={ classes.flexy }>
                     <Typography variant={ 'h3' } noWrap>{ (asset.apy ? (asset.apy).toFixed(2) : '0.00') }% </Typography>
@@ -472,7 +472,7 @@ class Vault extends Component {
               }
               {
                 (!['LINK'].includes(asset.id) && asset.vaultBalance === 0) &&
-                <div className={classes.headingEarning}>
+                <div className={classes.heading}>
                   <Typography variant={ 'h5' } className={ classes.grey }>APY:</Typography>
                   <div className={ classes.flexy }>
                     <Typography variant={ 'h3' } noWrap>{ (asset.apy ? (asset.apy).toFixed(2) : '0.00') }% </Typography>
@@ -481,7 +481,7 @@ class Vault extends Component {
               }
               {
                 ['LINK'].includes(asset.id) &&
-                <div className={classes.headingEarning}>
+                <div className={classes.heading}>
                   <Typography variant={ 'h5' } className={ classes.grey }>APY:</Typography>
                   <Typography variant={ 'h3' } noWrap>Not Available</Typography>
                 </div>
@@ -489,6 +489,10 @@ class Vault extends Component {
               <div className={classes.heading}>
                 <Typography variant={ 'h5' } className={ classes.grey }>Your wallet:</Typography>
                 <Typography variant={ 'h3' } noWrap>{ (asset.balance ? (asset.balance).toFixed(2) : '0.00')+' '+asset.symbol }</Typography>
+              </div>
+              <div className={classes.heading}>
+                <Typography variant={ 'h5' } className={ classes.grey }>Your vault:</Typography>
+                <Typography variant={ 'h3' } noWrap>{ (asset.vaultBalance ? ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(2) : '0.00')+' '+asset.symbol }</Typography>
               </div>
             </div>
           </AccordionSummary>


### PR DESCRIPTION
Small tweaks to show vault balance and underlying asset balance in a different way that is more clear for people to understand the value the are earning. Also some changes to wallet balance label and vault balance label.

Changed the interest rate to APY (controversial change).
<img width="736" alt="Screen Shot 2020-09-11 at 19 35 44" src="https://user-images.githubusercontent.com/839844/92980372-551f9580-f46c-11ea-92d2-a2eb29aa72f9.png">
<img width="718" alt="Screen Shot 2020-09-11 at 19 38 51" src="https://user-images.githubusercontent.com/839844/92980375-5650c280-f46c-11ea-8ec0-b412751545d1.png">

