### PR TITLE
Show Vaults' values in the underlaying asset

### DIFF
--- a/src/components/vault/asset.jsx
+++ b/src/components/vault/asset.jsx
@@ -165,7 +165,7 @@ class Asset extends Component {
     return (<div className={ classes.actionsContainer }>
       <div className={ classes.tradeContainer }>
         <div className={ classes.balances }>
-            <Typography variant='h4' onClick={ () => { this.setAmount(100) } } className={ classes.value } noWrap>{ 'Balance: '+ (asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset.tokenSymbol ? asset.tokenSymbol : asset.symbol }</Typography>
+            <Typography variant='h4' onClick={ () => { this.setAmount(100) } } className={ classes.value } noWrap>{ 'Your wallet: '+ (asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset.tokenSymbol ? asset.tokenSymbol : asset.symbol }</Typography>
         </div>
         <TextField
           fullWidth
@@ -204,14 +204,6 @@ class Asset extends Component {
             onClick={ () => { this.setAmount(75) } }>
             <Typography variant={'h5'}>75%</Typography>
           </Button>
-          <Button
-            className={ classes.scale }
-            variant='text'
-            disabled={ loading }
-            color="primary"
-            onClick={ () => { this.setAmount(100) } }>
-            <Typography variant={'h5'}>100%</Typography>
-          </Button>
         </div>
         <div className={ classes.buttons }>
           { asset.deposit === true &&
@@ -248,7 +240,7 @@ class Asset extends Component {
       <div className={ classes.sepperator }></div>
       <div className={classes.tradeContainer}>
         <div className={ classes.balances }>
-          <Typography variant='h4' onClick={ () => { this.setRedeemAmount(100) } }  className={ classes.value } noWrap>{ asset.vaultBalance ? (Math.floor(asset.vaultBalance*10000)/10000).toFixed(4) : '0.0000' } { asset.vaultSymbol } ({ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(4) : '0.0000') } { asset.symbol }) </Typography>
+          <Typography variant='h4' onClick={ () => { this.setRedeemAmount(100) } }  className={ classes.value } noWrap>{ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(4) : '0.0000') } { asset.symbol } ({ asset.vaultBalance ? (Math.floor(asset.vaultBalance*10000)/10000).toFixed(4) : '0.0000' } { asset.vaultSymbol }) </Typography>
         </div>
         <TextField
           fullWidth
@@ -286,14 +278,6 @@ class Asset extends Component {
             color="primary"
             onClick={ () => { this.setRedeemAmount(75) } }>
             <Typography variant={'h5'}>75%</Typography>
-          </Button>
-          <Button
-            className={ classes.scale }
-            variant='text'
-            disabled={ loading }
-            color="primary"
-            onClick={ () => { this.setRedeemAmount(100) } }>
-            <Typography variant={'h5'}>100%</Typography>
           </Button>
         </div>
         <div className={ classes.buttons }>
@@ -365,8 +349,8 @@ class Asset extends Component {
   onWithdraw = () => {
     this.setState({ redeemAmountError: false })
 
-    const { redeemAmount } = this.state
     const { asset, startLoading  } = this.props
+    const redeemAmount = this.state.redeemAmount/asset.pricePerFullShare
 
     if(!redeemAmount || isNaN(redeemAmount) || redeemAmount <= 0 || redeemAmount > asset.vaultBalance) {
       this.setState({ redeemAmountError: true })
@@ -406,7 +390,7 @@ class Asset extends Component {
       return
     }
 
-    const balance = this.props.asset.vaultBalance
+    const balance = this.props.asset.vaultBalance*this.props.asset.pricePerFullShare
     let amount = balance*percent/100
     amount = Math.floor(amount*10000)/10000;
 

--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -466,7 +466,7 @@ class Vault extends Component {
                   <div className={ classes.flexy }>
                     <Typography variant={ 'h3' } noWrap>{ (asset.apy ? (asset.apy).toFixed(2) : '0.00') }% </Typography>
                     <Typography variant={ 'h5' } className={ classes.on }> on </Typography>
-                    <Typography variant={ 'h3' } noWrap>{ (asset.vaultBalance ? (asset.vaultBalance).toFixed(2) : '0.00') } {asset.vaultSymbol}</Typography>
+                    <Typography variant={ 'h3' } noWrap>{ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(2) : '0.00') } {asset.vaultSymbol}</Typography>
                   </div>
                 </div>
               }


### PR DESCRIPTION
Thanks @antonnell for the review of the PR #74. This is an improvement on that one.

This question is a recurrent question in Telegram support group and Discord. I want to improve user experience using the page but with only small tweaks I believe will be a win.

<img width="459" alt="Screen Shot 2020-09-14 at 14 36 51" src="https://user-images.githubusercontent.com/839844/93157010-b9965b00-f6df-11ea-989c-0c01cb9313ee.png">

To improve clarity and consistence, I propose deposits and withdrawals to be expressed in the underlaying asset, in this example: **DAI**. So for 25%, 50% and 75%, behind scenes the amount to withdraw is: `redeemAmount/asset.pricePerFullShare`. But the user will always see amounts in **DAI**. Being more clear and consistent with what the user wants: **withdraw DAIs**.

<img width="676" alt="Screen Shot 2020-09-14 at 20 41 00" src="https://user-images.githubusercontent.com/839844/93157042-cf0b8500-f6df-11ea-854d-254ecd0b7e5b.png">


100% is covered by _Withdraw All_. Because the 100% is not easy to calculate accurately when converting from DAI to yDAI, the best way is to call use _Withdraw All_ button and let it claim all the funds at once.

<img width="676" alt="Screen Shot 2020-09-14 at 20 41 11" src="https://user-images.githubusercontent.com/839844/93157066-dd59a100-f6df-11ea-9ae2-bb9b1ec22ba3.png">
