### PR TITLE
Updated footer with nice working Discord link

### DIFF
--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -193,7 +193,7 @@ class Footer extends Component {
             <img alt="" src={ require('../../assets/medium.svg') } height='24px' className={ classes.icon } />
             <Typography variant={ 'h4'} >Medium</Typography>
           </div>
-          <div  className={ classes.link } onClick={()=> window.open("https://discord.gg/GcjxhWR", "_blank")} >
+          <div  className={ classes.link } onClick={()=> window.open("https://discord.yearn.finance", "_blank")} >
             <img alt="" src={ require('../../assets/discord.svg') } height='24px' className={ classes.icon } />
             <Typography variant={ 'h4'} >Discord</Typography>
           </div>


### PR DESCRIPTION
The Discord invite is not working. Here it is the footer with a nice Discord link instead of the ugly invite. DNS changes are needed.