### PR TITLE
vaultSymbol should be symbol

### DIFF
--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -484,7 +484,7 @@ class Vault extends Component {
                   <div className={ classes.flexy }>
                     <Typography variant={ 'h3' } noWrap>{ (this._getAPY(asset)/1).toFixed(2) }% </Typography>
                     <Typography variant={ 'h5' } className={ classes.on }> on </Typography>
-                    <Typography variant={ 'h3' } noWrap>{ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(2) : '0.00') } {asset.vaultSymbol}</Typography>
+                    <Typography variant={ 'h3' } noWrap>{ (asset.vaultBalance ? (Math.floor(asset.vaultBalance*asset.pricePerFullShare*10000)/10000).toFixed(2) : '0.00') } {asset.symbol}</Typography>
                   </div>
                 </div>
               }


### PR DESCRIPTION
I found a tiny little mistake. In the accordion header, the vault symbol is shown but it should be the token symbol. In the image attached is better appreciated.

<img width="945" alt="vault symbol" src="https://user-images.githubusercontent.com/839844/93611929-47ef3300-f9a5-11ea-80dd-427d7f69efc3.png">
