### PR TITLE
Fix Strategy Name column overlapping on stats page

### DIFF
--- a/src/components/apr/apr.jsx
+++ b/src/components/apr/apr.jsx
@@ -52,7 +52,7 @@ const styles = theme => ({
     display: 'flex',
     alignItems: 'center',
     padding: '8px 0px',
-    width: '260px',
+    width: '240px',
     top: 'auto',
     cursor: 'pointer'
   },
@@ -61,7 +61,7 @@ const styles = theme => ({
     alignItems: 'center',
     top: 'auto',
     padding: '8px 0px',
-    width: '130px',
+    width: '160px',
     cursor: 'pointer'
   },
   apr1: {
@@ -96,12 +96,12 @@ const styles = theme => ({
   headerName: {
     fontWeight: 'bold',
     padding: '8px 0px',
-    width: '260px'
+    width: '240px'
   },
   headerStrategy: {
     fontWeight: 'bold',
     padding: '8px 0px',
-    width: '130px'
+    width: '160px'
   },
   aggregatedHeader: {
     textAlign: 'left',

--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -2543,10 +2543,11 @@ class Store {
 
       const strategyContract = new web3.eth.Contract(config.vaultStrategyABI, strategyAddress)
       const holdings = await strategyContract.methods.balanceOf().call({ from: account.address })
-      let strategyName = 'StrategyDForceUSDC'
+      let strategyName = 'DForceUSDC'
 
       if(!['USDC'].includes(asset.id)) {
         strategyName = await strategyContract.methods.getName().call({ from: account.address })
+        strategyName = strategyName.replace(/^Strategy/, '')
       }
 
       callback(null, {


### PR DESCRIPTION
This resolves https://github.com/iearn-finance/iearn-finance/issues/88.

We're simply removing the `Strategy` prefix from the strategy name and updating some fixed column widths.

Still looks great at a normal resolution.
![image](https://user-images.githubusercontent.com/16483341/93975928-0b1c9680-fd2d-11ea-8a39-5583c7683c4e.png)

This is what it looks like at 1024x1202. The bug reporter mentioned his laptop having a 13". Most 13" laptops have either a 1280-by-800 or 1366-by-768 resolution.
![image](https://user-images.githubusercontent.com/16483341/93977135-e4f7f600-fd2e-11ea-8e1f-cc85ea3e391d.png)

This is what it looked like at 1024x1202 **before**:
![image](https://user-images.githubusercontent.com/16483341/93977390-3e602500-fd2f-11ea-994d-6bc05e087840.png)
