### PR TITLE
Mobile header adjustments

### DIFF
--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -49,7 +49,10 @@ const styles = theme => ({
     cursor: 'pointer'
   },
   links: {
-    display: 'flex'
+    display: 'flex',
+    [theme.breakpoints.down('sm')]: {
+      flexWrap: 'wrap',
+    }
   },
   link: {
     padding: '12px 0px',
@@ -58,7 +61,7 @@ const styles = theme => ({
     '&:hover': {
       paddingBottom: '9px',
       borderBottom: "3px solid "+colors.borderBlue,
-    },
+    }
   },
   title: {
     textTransform: 'capitalize'
@@ -93,7 +96,7 @@ const styles = theme => ({
     [theme.breakpoints.down('sm')]: {
       display: 'flex',
       position: 'absolute',
-      top: '90px',
+      transform: 'translate(0, 200%)',
       border: "1px solid "+colors.borderBlue,
       background: colors.white
     }


### PR DESCRIPTION
This PR adjusts the header on mobile so it shows all the links and there's no horizontal scrolling. 

before (current):

![Screenshot from 2020-09-28 12-17-30](https://user-images.githubusercontent.com/168240/94477506-dbcfb480-0186-11eb-945b-b2a23913ee60.png)

after:

![Screenshot from 2020-09-28 12-30-51](https://user-images.githubusercontent.com/168240/94477515-dd997800-0186-11eb-99af-c05d684eb1c1.png)

after (gif):

![Peek 2020-09-28 12-31](https://user-images.githubusercontent.com/168240/94477521-dffbd200-0186-11eb-9931-ea3ba204d3e2.gif)
