### PR TITLE
Fix WalletLink AppName

### DIFF
--- a/src/stores/connectors.jsx
+++ b/src/stores/connectors.jsx
@@ -36,7 +36,7 @@ export const walletconnect = new WalletConnectConnector({
 
 export const walletlink = new WalletLinkConnector({
   url: RPC_URLS[1],
-  appName: "iearn.financaae"
+  appName: "yearn.finance"
 });
 
 export const ledger = new LedgerConnector({


### PR DESCRIPTION
Problem: WalletLink appName was misspelt as "iearn.financaae"

Solution: Rename to "yearn.finance"