### PR TITLE
Add action to deploy bundle to AWS

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -1,0 +1,44 @@
+name: Production Build Deployment
+on:
+  push:
+    branches:
+      - master
+      - y
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        run: |
+          npm install .
+      - name: Run unit tests
+        run: |
+          CI=true npm test --watch=all
+      - name: Create a production bundle.
+        run: |
+          npm run-script build
+    
+      - name: Deploy to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_PRODUCTION_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SOURCE_DIR: "build"
+      
+      - name: Invalidate CloudFront caches
+        uses: awact/cloudfront-action@master
+        env:
+          SOURCE_PATH: '/*'
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          DISTRIBUTION_ID: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
### Description

Add a Github Action that tests, builds, and deploys the production bundle to an S3 bucket and invalidates the CloudFront caches on merge into branches: `y`, `master`.

### Validation

Push changes to branches: `y`, or `master` on my fork https://github.com/arberx/iearn-finance (should be unprotected), and validate the changes are reflected at:
http://test-iearn-finance-deployer.s3-website.us-east-2.amazonaws.com/ on successful action completion and: http://d2tm5ynox8963w.cloudfront.net for CloudFront deployment.

Example successful validation: https://github.com/arberx/iearn-finance/runs/1269868642

### Admin Changes needed. 

The following secret fields need to be added to the repo:

- `AWS_PRODUCTION_BUCKET_NAME`
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_REGION`
- `AWS_CLOUDFRONT_DISTRIBUTION_ID`

And the `S3` bucket needs to have the proper public permissions.
