### PR TITLE
Use chainId instead of deprecated networkVersion

### DIFF
--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -158,7 +158,7 @@ class Header extends Component {
       const provider = context.library.provider
       const account = store.getStore('account')
       const { address } = account
-      const network = provider.networkVersion
+      const network = provider.chainId
       const ens = new ENS({ provider, network })
       const addressEnsName = await ens.reverse(address).catch(() => {})
       if (addressEnsName) {

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -158,7 +158,7 @@ class Header extends Component {
       const provider = context.library.provider
       const account = store.getStore('account')
       const { address } = account
-      const network = provider.chainId
+      const network = provider.chainId || provider.networkVersion
       const ens = new ENS({ provider, network })
       const addressEnsName = await ens.reverse(address).catch(() => {})
       if (addressEnsName) {


### PR DESCRIPTION
Currently running the website locally will hit this error because network is null.
![image](https://user-images.githubusercontent.com/7820952/96358943-891c5500-10c1-11eb-89aa-048fd5394753.png)

ethereum.networkVersion is [deprecated](https://docs.metamask.io/guide/ethereum-provider.html#ethereum-networkversion-deprecated) according to the metamask documenation. They say to prefer chainId.

Switching to chainId gets rid of this error.