### PR TITLE
Add friendly error for metamask users that are not on main net 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,8 @@ import { injected } from "./stores/connectors";
 
 import {
   CONNECTION_CONNECTED,
+  CONNECTION_DISCONNECTED,
+  ERROR
 } from './constants'
 
 import Store from "./stores";
@@ -40,8 +42,18 @@ class App extends Component {
       if (isAuthorized) {
         injected.activate()
         .then((a) => {
-          store.setStore({ account: { address: a.account }, web3context: { library: { provider: a.provider } } })
-          emitter.emit(CONNECTION_CONNECTED)
+          store.setStore({ web3context: { library: { provider: a.provider } } })
+          const networkChainId = a.provider.chainId
+
+          if ( networkChainId === "0x1" ) {
+            store.setStore({ account: { address: a.account } })
+            emitter.emit(CONNECTION_CONNECTED)
+          } else {
+            store.setStore({ account: { }, web3context: null })
+            emitter.emit(CONNECTION_DISCONNECTED)
+            emitter.emit(ERROR, "You are not connected to the Main Ethereum Network. Please change your network in your Ethereum wallet.")
+          }
+        
         })
         .catch((e) => {
           console.log(e)
@@ -60,6 +72,9 @@ class App extends Component {
           emitter.emit(CONNECTION_CONNECTED)
         }
       })
+
+      
+
     }
   }
 

--- a/src/components/apr/apr.jsx
+++ b/src/components/apr/apr.jsx
@@ -15,6 +15,7 @@ import {
 } from '../../constants'
 
 import Loader from '../loader'
+import Snackbar from '../snackbar'
 
 import Store from "../../stores";
 const emitter = Store.emitter
@@ -187,6 +188,18 @@ class APR extends Component {
     this.setState({ account: store.getStore('account') })
   }
 
+  errorReturned = (error) => {
+    const snackbarObj = { snackbarMessage: null, snackbarType: null }
+    this.setState(snackbarObj)
+    this.setState({ loading: false })
+    const that = this
+    setTimeout(() => {
+      const snackbarObj = { snackbarMessage: error.toString(), snackbarType: 'Error' }
+      that.setState(snackbarObj)
+    })
+  };
+
+
   statisticsReturned = (balances) => {
     this.setState({
       assets: store.getStore('vaultAssets'),
@@ -196,7 +209,7 @@ class APR extends Component {
 
   render() {
     const { classes } = this.props;
-    const { loading } = this.state
+    const { loading, snackbarMessage } = this.state
 
     return (
       <div className={ classes.root }>
@@ -211,6 +224,7 @@ class APR extends Component {
           </table>
         </Card>
         { loading && <Loader /> }
+        { snackbarMessage && this.renderSnackbar() }
       </div>
     )
   };
@@ -310,6 +324,15 @@ class APR extends Component {
       })
     )
   }
+
+  renderSnackbar = () => {
+    var {
+      snackbarType,
+      snackbarMessage
+    } = this.state
+    return <Snackbar type={snackbarType} message={snackbarMessage} open={true}/>
+  };
+
 }
 
 export default withRouter(withStyles(styles)(APR));

--- a/src/components/dashboard/dashboard.jsx
+++ b/src/components/dashboard/dashboard.jsx
@@ -7,7 +7,7 @@ import {
   MenuItem
 } from '@material-ui/core';
 import { colors } from '../../theme'
-
+import Snackbar from '../snackbar'
 import Loader from '../loader'
 import InfoIcon from '@material-ui/icons/Info';
 
@@ -247,8 +247,16 @@ class Dashboard extends Component {
   };
 
   errorReturned = (error) => {
+    const snackbarObj = { snackbarMessage: null, snackbarType: null }
+    this.setState(snackbarObj)
     this.setState({ loading: false })
+    const that = this
+    setTimeout(() => {
+      const snackbarObj = { snackbarMessage: error.toString(), snackbarType: 'Error' }
+      that.setState(snackbarObj)
+    })
   };
+
 
   render() {
     const { classes } = this.props;
@@ -258,6 +266,7 @@ class Dashboard extends Component {
       growth,
       currency,
       account,
+      snackbarMessage
     } = this.state
 
     if(!account || !account.address) {
@@ -269,6 +278,7 @@ class Dashboard extends Component {
               <Typography variant='h3'>Connect your wallet to continue</Typography>
             </div>
           </div>
+          { snackbarMessage && this.renderSnackbar() }
         </div>
       )
     }
@@ -661,6 +671,14 @@ class Dashboard extends Component {
       return '0.00'
     }
   }
+
+  renderSnackbar = () => {
+    var {
+      snackbarType,
+      snackbarMessage
+    } = this.state
+    return <Snackbar type={ snackbarType } message={snackbarMessage} open={true}/>
+  };
 
 }
 

--- a/src/components/unlock/unlock.jsx
+++ b/src/components/unlock/unlock.jsx
@@ -216,8 +216,20 @@ function MyComponent(props) {
 
   React.useEffect(() => {
     if (account && active && library) {
-      store.setStore({ account: { address: account }, web3context: context })
+      
+    store.setStore({ web3context: context });      
+    const networkChainId = library.provider.chainId
+
+    if ( networkChainId === '0x1') {
+      store.setStore({ account: { address: account }})
       emitter.emit(CONNECTION_CONNECTED)
+    } else {
+      deactivate();
+      emitter.emit(CONNECTION_DISCONNECTED)
+      store.setStore({ account: { }, web3context: null })
+      emitter.emit(ERROR, "You are not connected to the Main Ethereum Network. Please change your network in your Ethereum wallet.")
+    }
+      
     }
   }, [account, active, closeModal, context, library]);
 


### PR DESCRIPTION
Closes #111 

# Changelog

- Add metamask mainnet logic on unlock.jsx (upon connect your wallet)
- Add metamask mainnet logic on App.js (upon page load)
- Add snackbar error UI in dashboard page
- Add snackbar error UI in stats page

# Acceptance Criteria

**1. Attempting to connect Metamask outside of main net will prevent connection and pop up a friendly snackbar error across pages:**

- Dashboard (required Snackbar UI to be added)
- Vaults
- Earn
- Zap
- Cover: N/A - need to be applied to separate repo similar to ygov
- Stats (required Snackbar UI to be added)
 
**2. Changing metamask from main net to a test net will disconnect user on next page refresh**
Logic is on `componentWillMount` in `App.js` so this will only trigger upon next page refresh. An improvement will be to use a web3 event but this may be overkill given that this is an edge case.

**3. Everything else still works +1**

# Additional Testing Required
- Trustwallet also uses the `injected` connector: does this behave consistently with web3 as does Metamask?
- Stats page is not loading on local environment so difficult to test 