### PR TITLE
chore: show GUSD as disabled and add information about why

### DIFF
--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -529,8 +529,8 @@ class Vault extends Component {
                 <div className={classes.headingEarning}>
                   <Typography variant={ 'h5' } className={ classes.grey }>Yearly Growth:</Typography>
                   <Typography variant={ 'h3' }  noWrap>
-                    Strategy Disabled
-                    <Tooltip title="The GUSD strategy has been disabled due to a recent bug that caused a misleading APY calculation. It is safe to withdraw your funds. You will not be charged the 0.5% fee for this withdrawal." arrow>
+                    Not Available
+                    <Tooltip title="The GUSD strategy is temporally disabled due to misleading APY calculation. It is safe to withdraw your funds, you are not charged 0.5% withdrawal fee." arrow>
                       <InfoIcon fontSize="small" style={{ color: colors.darkGray, marginLeft: '5px', marginBottom: '-5px' }} />
                     </Tooltip>
                   </Typography>

--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -509,7 +509,7 @@ class Vault extends Component {
                 </div>
               }
               {
-                (!['LINK'].includes(asset.id) && asset.vaultBalance === 0) &&
+                (!['LINK'].includes(asset.id) && !['GUSD'].includes(asset.id) && asset.vaultBalance === 0) &&
                 <div className={classes.headingEarning}>
                   <Typography variant={ 'h5' } className={ classes.grey }>Yearly Growth:</Typography>
                   <div className={ classes.flexy }>
@@ -524,7 +524,18 @@ class Vault extends Component {
                   <Typography variant={ 'h3' } noWrap>Not Available</Typography>
                 </div>
               }
-
+              {
+                ['GUSD'].includes(asset.id) &&
+                <div className={classes.headingEarning}>
+                  <Typography variant={ 'h5' } className={ classes.grey }>Yearly Growth:</Typography>
+                  <Typography variant={ 'h3' }  noWrap>
+                    Strategy Disabled
+                    <Tooltip title="The GUSD strategy has been disabled due to a recent bug that caused a misleading APY calculation. It is safe to withdraw your funds. You will not be charged the 0.5% fee for this withdrawal." arrow>
+                      <InfoIcon fontSize="small" style={{ color: colors.darkGray, marginLeft: '5px', marginBottom: '-5px' }} />
+                    </Tooltip>
+                  </Typography>
+                </div>
+              }
               { !(asset.depositDisabled === true) &&
                 <div className={classes.heading}>
                   <Typography variant={ 'h5' } className={ classes.grey }>Available to deposit:</Typography>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7820952/97645726-f0fc6500-1a0a-11eb-83cc-1b026925b3d2.png)

The GUSD APY shows as above 2000% currently, despite the strategy being disabled and making no money. This is confusing to new users and causes people to deposit thinking they will make a ton of gains. 

This PR hides the false APY with a "Strategy Disabled" text and adds a tooltip with a longer explanation why.