### PR TITLE
fix: visual regression in GUSD vault from PR #176

### DIFF
--- a/src/components/vault/vault.jsx
+++ b/src/components/vault/vault.jsx
@@ -498,7 +498,7 @@ class Vault extends Component {
                 </div>
               </div>
               {
-                (!['LINK'].includes(asset.id) && asset.vaultBalance > 0) &&
+                (!['LINK'].includes(asset.id) && !['GUSD'].includes(asset.id) && asset.vaultBalance > 0) &&
                 <div className={classes.headingEarning}>
                   <Typography variant={ 'h5' } className={ classes.grey }>Yearly Growth:</Typography>
                   <div className={ classes.flexy }>


### PR DESCRIPTION
PR #176 attempted to fix #177, however it introduced a visual bug where any user with yGUSD in their wallet would see a weird UI with 2 Yearly Growths shown:
![image](https://user-images.githubusercontent.com/7820952/97731287-2b5d1500-1a92-11eb-8476-0f430ad8e061.png)

This PR fixes this issue by disabling the Yearly Growth element for GUSD (when balance > 0) in the same way it is done for LINK. This case was not fully handled in #176 