### PR TITLE
fix: use all sources of CRV for approval check

### DIFF
--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -3930,8 +3930,8 @@ class Store {
   zapExperimentalVault = (payload) => {
     const account = store.getStore('account')
     const { asset } = payload.content
-
-    this._checkApproval(asset, account, asset.balance, asset.zapContractAddress, (err) => {
+    const zappableCrv = asset.balance + asset.gaugeBalance + asset.vested;
+    this._checkApproval(asset, account, zappableCrv, asset.zapContractAddress, (err) => {
       if(err) {
         return emitter.emit(ERROR, err);
       }


### PR DESCRIPTION
Currently, users who have vested CRV or pending CRV rewards in gauges, but no CRV in their wallet, do not get prompted to approve CRV spend.

Currently, the checkApproval call for CRV spend on the zap just takes into account the CRV wallet balance, which does not prompt approval if the CRV in the wallet is 0.

This PR changes the check to take into account all of the CRV that will be zapped. 