### PR TITLE
fix: file claim text not being visible on button

### DIFF
--- a/src/components/cover/existingCover.jsx
+++ b/src/components/cover/existingCover.jsx
@@ -63,7 +63,7 @@ const styles = theme => ({
   },
   actionButton: {
     borderRadius: '6px',
-    width: '130px',
+    width: '160px',
     height: '30px',
     fontSize: '14px'
   },


### PR DESCRIPTION
Before :
![image](https://user-images.githubusercontent.com/25401217/101701952-f7addb80-3a90-11eb-90b7-8126c4caff23.png)
After:
![image](https://user-images.githubusercontent.com/25401217/101701975-05fbf780-3a91-11eb-859b-1201e743717f.png)
